### PR TITLE
Fix logic in mu-loader.php to support different plugin file names

### DIFF
--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -8,9 +8,18 @@
 
 defined( 'ABSPATH' ) || exit;
 
-foreach ( glob( __DIR__ . '/*', GLOB_ONLYDIR ) as $bpd_mu_plugin_dir ) {
-	$bpd_plugin = $bpd_mu_plugin_dir . DIRECTORY_SEPARATOR . basename( $bpd_mu_plugin_dir ) . '.php';
-	if ( file_exists( $bpd_plugin ) ) {
-		require_once $bpd_plugin;
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $file ) {
+	if ( ! is_readable( $file ) ) {
+		continue;
 	}
+
+	$plugin_data = get_plugin_data( $file, false, false );
+
+	if ( empty( $plugin_data['Name'] ) ) {
+		continue;
+	}
+
+	include_once $file;
 }

--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -10,16 +10,16 @@ defined( 'ABSPATH' ) || exit;
 
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $file ) {
-	if ( ! is_readable( $file ) ) {
+foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $t51_file ) {
+	if ( ! is_readable( $t51_file ) ) {
 		continue;
 	}
 
-	$plugin_data = get_plugin_data( $file, false, false );
+	$t51_plugin_data = get_plugin_data( $t51_file, false, false );
 
-	if ( empty( $plugin_data['Name'] ) ) {
+	if ( empty( $t51_plugin_data['Name'] ) ) {
 		continue;
 	}
 
-	include_once $file;
+	include_once $t51_file;
 }


### PR DESCRIPTION
Updated mu-loader.php to address an issue where the main plugin file in the mu_plugins directory was required to have the same name as the directory. The refactored code now loops through all PHP files in the directories, uses get_plugin_data to check for a valid plugin header, and includes the files accordingly. This change allows mu-plugins to be added regardless of the main file name.

#### Changes proposed in this Pull Request

* Loops through all PHP files in the directories and uses `get_plugin_data` to check if it has a plugin header.

#### Testing instructions

1. Ensure `mu-loader.php` is in the `mu_plugins` directory
2. Install Hello Dolly plugin
3. Move it to the `mu_plugins` directory
4. Confirm that the plugin is installed. For example, there's a lyric in the upper right of the admin screen.

Mentions #8 
