### PR TITLE
Use plugins_list filter to add mu-plugins to list

### DIFF
--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -14,3 +14,27 @@ foreach ( glob( __DIR__ . '/*', GLOB_ONLYDIR ) as $bpd_mu_plugin_dir ) {
 		require_once $bpd_plugin;
 	}
 }
+
+/**
+ * Adds the mu-plugins to the plugins list.
+ *
+ * @param array $plugins An array of plugins to list.
+ *
+ * @return array
+ */
+function t51_mu_plugin_filter( array $plugins ): array {
+	unset( $plugins['mustuse']['mu-loader.php'] );
+
+	foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $file ) {
+		$plugin_data = get_plugin_data( $file, false, false );
+
+		if ( empty( $plugin_data['Name'] ) ) {
+			continue;
+		}
+
+		$plugins['mustuse'][ basename( $file ) ] = $plugin_data;
+	}
+
+	return $plugins;
+}
+add_filter( 'plugins_list', 't51_mu_plugin_filter' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses the `plugins_list` filter in 6.3 to add the must-use plugins to the list in the admin
* Removes `mu-loader.php` from the list in the admin

#### Testing instructions

* Make sure you have at least WordPress 6.3 beta 4 installed. You can do that with the command `wp core update --version=6.3-beta4`.
* Add plugins to the mu-plugins directory
* In the admin, go to Plugins > Installed Plugins and click the Must-Use link at the top of the page
* Confirm that you see the plugins you added
* Confirm that you don't see `mu-loader.php` listed

It should look something like this:
![Screenshot 2023-07-12 at 7 56 14 AM](https://github.com/a8cteam51/team51-project-scaffold/assets/8797898/e6ec3346-c90e-40fa-8439-f9cfacf9bb67)

