### PR TITLE
Proposal/mu loader refactoring

### DIFF
--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -10,18 +10,11 @@ defined( 'ABSPATH' ) || exit;
 
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $t51_file ) {
-	if ( ! is_readable( $t51_file ) ) {
-		continue;
+foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $bpd_mu_plugin_file ) {
+	$bpd_mu_plugin_data = get_plugin_data( $bpd_mu_plugin_file, false, false );
+	if ( ! empty( $bpd_mu_plugin_data['Name'] ) ) {
+		require_once $bpd_mu_plugin_file;
 	}
-
-	$t51_plugin_data = get_plugin_data( $t51_file, false, false );
-
-	if ( empty( $t51_plugin_data['Name'] ) ) {
-		continue;
-	}
-
-	include_once $t51_file;
 }
 
 /**

--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -18,25 +18,24 @@ foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $bpd_mu_plugin_file ) {
 }
 
 /**
- * Adds the mu-plugins to the plugins list.
+ * Adds the mu-plugins to the admin plugins list.
  *
- * @param array $plugins An array of plugins to list.
+ * @param   array $plugins An array of plugins to list.
  *
- * @return array
+ * @return  array
  */
-function t51_mu_plugin_filter( array $plugins ): array {
-	unset( $plugins['mustuse']['mu-loader.php'] );
+add_filter(
+	'plugins_list',
+	static function ( array $plugins ): array {
+		unset( $plugins['mustuse']['mu-loader.php'] ); // Remove this file from the list.
 
-	foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $file ) {
-		$plugin_data = get_plugin_data( $file, false, false );
-
-		if ( empty( $plugin_data['Name'] ) ) {
-			continue;
+		foreach ( glob( WPMU_PLUGIN_DIR . '/*/*.php' ) as $file ) {
+			$plugin_data = get_plugin_data( $file, false, false );
+			if ( ! empty( $plugin_data['Name'] ) ) {
+				$plugins['mustuse'][ basename( $file ) ] = $plugin_data;
+			}
 		}
 
-		$plugins['mustuse'][ basename( $file ) ] = $plugin_data;
+		return $plugins;
 	}
-
-	return $plugins;
-}
-add_filter( 'plugins_list', 't51_mu_plugin_filter' );
+);

--- a/mu-plugins/mu-loader.php
+++ b/mu-plugins/mu-loader.php
@@ -2,8 +2,8 @@
 /**
  * By default, WordPress will load all files in the mu-plugins directory and ignore all the directories inside.
  *
- * This file is a workaround which will load all the plugins in the mu-plugins directory which follow the naming
- * convention of `plugin-name/plugin-name.php`.
+ * This file is a workaround which will load all the plugins in the mu-plugins directory which have a root-level file
+ * containing a plugin header (@link https://developer.wordpress.org/plugins/plugin-basics/header-requirements/).
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the file's header description to match what's actually being loaded now. 
* Remove the `is_readable` check since `get_plugin_data` handles that by returning an empty array ... so it's checked/handled already
* Go back to prefixing global variables with the project's initials ... this could cause issues with project-level `phpcs` checks otherwise (hence why they were prefixed like that previously) + it makes it clear that the mu-plugins loaded aren't just Team51 ones necessarily, e.g. we sometimes load [Fieldmanager](https://fieldmanager.org/) like that as well
* Move the `plugins_list` filter to a static anonymous function like we do with other mandatory filters, for example: https://github.com/a8cteam51/team51-plugin-scaffold/blob/5043814181e5add7993120732696cfc1cb067c34/team51-plugin-scaffold.php#L41 
