### PR TITLE
Add Team51 prefix to phpcs ruleset

### DIFF
--- a/themes/build-processes-demo/.phpcs.xml
+++ b/themes/build-processes-demo/.phpcs.xml
@@ -18,6 +18,7 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
+				<element value="team51"/> <!-- Prefix used in some Team51 plugins, like Colophon. -->
 				<element value="build_processes_demo"/> <!-- Change this value to your theme prefix. -->
 				<element value="bpd"/> <!-- Change this value to your theme prefix. -->
 			</property>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds the Team51 prefix to the PHPCS ruleset, because some Team51 plugins have that prefix in functions used in the theme, like Colophon


