### PR TITLE
Add JS/CSS coding standard workflow

### DIFF
--- a/.github/workflows/js-css-coding-standards.yml
+++ b/.github/workflows/js-css-coding-standards.yml
@@ -1,4 +1,4 @@
-name: JS and CSS Coding Standards
+name: JS+CSS Coding Standards
 
 on:
   push:
@@ -11,29 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      # Adding Node.js setup to run JS and CSS linters
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Setup proper Node.js version
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.15'  # project version
+          node-version-file: 'package.json'
+          cache: 'npm''
 
-      - name: Get npm cache directory
-        id: npm-cache
-        run: echo "::set-output name=dir::$(npm config get cache)"
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-            ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install NPM dependencies
+      - name: Install dependencies
         run: npm ci
 
       - name: Run JS linter

--- a/.github/workflows/js-css-coding-standards.yml
+++ b/.github/workflows/js-css-coding-standards.yml
@@ -1,0 +1,43 @@
+name: JS and CSS Coding Standards
+
+on:
+  push:
+    branches: [ trunk, develop ]
+  pull_request:
+    branches: [ trunk, develop ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Adding Node.js setup to run JS and CSS linters
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.15'  # project version
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+            ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Run JS linter
+        run: npm run lint:scripts
+
+      - name: Run CSS linter
+        run: npm run lint:styles

--- a/.github/workflows/js-css-coding-standards.yml
+++ b/.github/workflows/js-css-coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
 
       # Adding Node.js setup to run JS and CSS linters
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.15'  # project version
 
@@ -24,7 +24,7 @@ jobs:
         run: echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache npm dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run JS linter
         run: npm run lint:scripts

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup proper PHP version
         uses: shivammathur/setup-php@v2
@@ -31,7 +31,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php-syntax-errors.yml
+++ b/.github/workflows/php-syntax-errors.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup proper PHP version
         uses: shivammathur/setup-php@v2

--- a/themes/build-processes-demo/assets/sass/abstracts/_mixins.scss
+++ b/themes/build-processes-demo/assets/sass/abstracts/_mixins.scss
@@ -3,6 +3,7 @@
 
 // Media query "greater than $breakpoint".
 @mixin breakpoint-up($breakpoint) {
+
 	@if map.has-key($breakpoints, $breakpoint) {
 		$breakpoint-value: map.get($breakpoints, $breakpoint);
 
@@ -10,12 +11,14 @@
 			@content;
 		}
 	} @else {
+
 		@warn "Undefined Breakpoint: (#{$breakpoint}). Available breakpoints: #{map.keys($breakpoints)}";
 	}
 }
 
 // Media query "less than $breakpoint".
 @mixin breakpoint-down($breakpoint) {
+
 	@if map.has-key($breakpoints, $breakpoint) {
 		$breakpoint-value: map.get($breakpoints, $breakpoint);
 
@@ -23,12 +26,14 @@
 			@content;
 		}
 	} @else {
+
 		@warn "Undefined Breakpoint: (#{$breakpoint}). Available breakpoints: #{map.keys($breakpoints)}";
 	}
 }
 
 // Media query "between $a and $b".
 @mixin breakpoint-between($a, $b) {
+
 	@if map.has-key($breakpoints, $a) and map.has-key($breakpoints, $b) {
 		$breakpoint-a: map.get($breakpoints, $a);
 		$breakpoint-b: map.get($breakpoints, $b);
@@ -37,10 +42,14 @@
 			@content;
 		}
 	} @else {
+
 		@if (map.has-key($breakpoints, $a) == false) {
+
 			@warn "Undefined Breakpoint: #{$a}. Available breakpoints: #{map.keys($breakpoints)}";
 		}
+
 		@if (map.has-key($breakpoints, $b) == false) {
+
 			@warn "Undefined Breakpoint: #{$b}. Available breakpoints: #{map.keys($breakpoints)}";
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds a JS/CSS coding standard GitHub workflow that runs the `lint:scripts` and ` int:styles` scripts

* Maybe we could divide the workflow into separate JS and CSS? We would use more GitHub minutes...

#### Testing instructions

1. Add some JS and CSS that throw errors with lint
2. Create a PR request with your branch
3. You should see the workflow run and throw errors
