### PR TITLE
Only check changed files for PHP coding standards

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -42,3 +42,21 @@ jobs:
 
       - name: Run PHP_CodeSniffer
         run: composer run-script lint:php
+
+      - name: Get list of changed files
+        id: get-changed-files
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          echo "changed_files<<EOF" >> $GITHUB_ENV
+          git diff --name-only origin/${{ github.base_ref }}..${{ github.sha }} >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Run PHP_CodeSniffer on changed files
+        run: |
+          for file in $changed_files
+          do
+            if [[ $file == *.php ]]
+            then
+              composer run-script lint:php:file -- $file
+            fi
+          done

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "format:php:theme": "phpcbf --standard=./themes/build-processes-demo/.phpcs.xml --basepath=. ./themes/build-processes-demo -v",
     "format:php:blocks": "phpcbf --standard=./mu-plugins/build-processes-demo-blocks/.phpcs.xml --basepath=. ./mu-plugins/build-processes-demo-blocks -v",
     "format:php:features": "phpcbf --standard=./mu-plugins/build-processes-demo-features/.phpcs.xml --basepath=. ./mu-plugins/build-processes-demo-features -v",
+    "format:php:file": "phpcbf --standard=./.phpcs.xml --basepath=. -v $*",
 
     "lint:php": [
       "@lint:php:theme",
@@ -62,6 +63,7 @@
     "lint:php:theme": "phpcs --standard=./themes/build-processes-demo/.phpcs.xml --basepath=. ./themes/build-processes-demo -v",
     "lint:php:blocks": "phpcs --standard=./mu-plugins/build-processes-demo-blocks/.phpcs.xml --basepath=. ./mu-plugins/build-processes-demo-blocks -v",
     "lint:php:features": "phpcs --standard=./mu-plugins/build-processes-demo-features/.phpcs.xml --basepath=. ./mu-plugins/build-processes-demo-features -v",
+    "lint:php:file": "phpcs --standard=./.phpcs.xml --basepath=. -v $*",
 
     "internationalize": [
       "@makepot:theme",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Composer script actions to lint or format specified files
* Updates the PHP Coding Standards action to only check changed files

This was implemented on Harvard Blogs: https://github.com/a8cteam51/harvard-blogs/pull/89

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Scaffold a site
* Make a branch and only change one PHP file
* Open a PR and confirm that the changed file is all that's scanned