### PR TITLE
Add rewrite args to CPT declaration

### DIFF
--- a/mu-plugins/build-processes-demo-features/includes/custom-post-types.php
+++ b/mu-plugins/build-processes-demo-features/includes/custom-post-types.php
@@ -52,8 +52,8 @@ function bpd_features_register_book_post_type(): void {
 		'can_export'          => true,
 		'has_archive'         => true,
 		'rewrite'             => array(
-			'slug'            => 'book',
-			'with_front'      => false,
+			'slug'       => 'book',
+			'with_front' => false,
 		),
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,

--- a/mu-plugins/build-processes-demo-features/includes/custom-post-types.php
+++ b/mu-plugins/build-processes-demo-features/includes/custom-post-types.php
@@ -51,6 +51,10 @@ function bpd_features_register_book_post_type(): void {
 		'menu_position'       => 5,
 		'can_export'          => true,
 		'has_archive'         => true,
+		'rewrite'             => array(
+			'slug'            => 'book',
+			'with_front'      => false,
+		),
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,
 		'capability_type'     => 'post',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds rewrite args to CPT declaration

#### Testing instructions

* CPT permalinks will remain unaffected by changing the base of the permalink structure in wp-admin. e.g. in this case, if you change the sitewide permalink structure to `/blog/%postname%/`, a book would still have a URL of `/book/%postname%/`

Mentions #18 
