### PR TITLE
Only lint JS files in the src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint:readme-md": "wp-scripts lint-md-docs README.md",
     "lint:scripts": "npm-run-all --sequential lint:scripts:**",
     "lint:scripts:theme": "wp-scripts lint-js themes/$npm_package_name --no-error-on-unmatched-pattern",
-    "lint:scripts:mu-plugins": "wp-scripts lint-js mu-plugins --no-error-on-unmatched-pattern",
+    "lint:scripts:mu-plugins": "wp-scripts lint-js 'mu-plugins/**/src/**/*.js' --no-error-on-unmatched-pattern",
     "lint:styles": "npm-run-all --sequential lint:styles:**",
     "lint:styles:theme": "wp-scripts lint-style themes/$npm_package_name/**/*.{css,sass,scss} !themes/$npm_package_name/style*.css --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
     "lint:styles:mu-plugins": "wp-scripts lint-style mu-plugins/**/*.{css,sass,scss} --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the logic to only lint JS files in a mu-plugin's `src` directory. This resolves an issue where the action hangs because it's trying to lint large compiled JS files
