### PR TITLE
Fix Premature Translation Loading by Updating get_plugin_data Parameters

### DIFF
--- a/mu-plugins/a8csp-project-scaffold-features/functions.php
+++ b/mu-plugins/a8csp-project-scaffold-features/functions.php
@@ -20,7 +20,7 @@ function a8csp_features_get_metadata( ?string $property = null ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_data = get_plugin_data( __DIR__ . '/a8csp-project-scaffold-features.php' );
+		$plugin_data = get_plugin_data( __DIR__ . '/a8csp-project-scaffold-features.php', true, false );
 	}
 
 	$metadata = $plugin_data;


### PR DESCRIPTION


#### Changes proposed in this Pull Request

This pull request addresses an issue where the translation loading was triggered too early, causing the following notice in WordPress 6.7.0 and later:

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the a8csp-project-scaffold-features domain was triggered too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.)
```

Mentions #28 
