### PR TITLE
Clear out the Scaffold action, after it's done running.

### DIFF
--- a/.github/workflows/fill-in-scaffold.yml
+++ b/.github/workflows/fill-in-scaffold.yml
@@ -47,5 +47,12 @@ jobs:
       - name: Commit the changed files.
         run: git commit -am "chore -- fill in scaffolding placeholders"
 
+      - name: Clear out this fill-in-scaffold action (as it won‘t need to run again)
+        run: |
+          rm -f .github/workflows/fill-in-scaffold.yml
+          rm -f .github/workflows/fill-in-scaffold.mjs
+          git add .github/workflows
+          git commit -m "chore -- clear scaffold action"
+
       - name: Push all the changed files.
         run: git push


### PR DESCRIPTION
cc: @ahegyes 

Was playing with a variant of this action in another repository, and noticed that the fill-in-scaffold was left behind and still nominally runnable after the first run.

Figured may as well have it tidy up after itself.  Hope it's useful to y'all.  <3