### PR TITLE
test: confirm block-json-check fires (throwaway)

### DIFF
--- a/blocks/throwaway-zizmor-test/block.json
+++ b/blocks/throwaway-zizmor-test/block.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "a8csp/throwaway-zizmor-test",
+	"version": "0.1.0",
+	"title": "Throwaway block.json check test",
+	"category": "widgets",
+	"icon": "smiley"
+}


### PR DESCRIPTION
Throwaway test of the merged block-json-check (tj-actions@v47 + array fix). Expect it to FAIL with a block.json caution comment. Delete after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new widget block option available in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->