### PR TITLE
Add composer + npm to Dependabot; add update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,36 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      composer:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "composer"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "npm"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Extends Dependabot to the composer and npm manifests so scaffolded projects inherit dependency-version coverage -- previously github-actions only, leaving the npm/composer trees with alerts but no bump PRs. Adds a 7-day cooldown to each ecosystem.

Assisted-by: Claude Code:claude-opus-4-8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency management with rate-limiting controls.
  * Expanded update coverage to additional package managers with controlled rollout frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->