### PR TITLE
zizmor: disable online audits (unresolvable cross-repo @trunk refs)

### DIFF
--- a/.github/workflows/workflow-checks.yml
+++ b/.github/workflows/workflow-checks.yml
@@ -50,8 +50,12 @@ jobs:
       # scaffolded from it) get free code scanning, so zizmor uploads SARIF to the
       # Security tab. Private projects on the Free plan have no code scanning, so it
       # runs advisory -- findings print in the Actions log and never fail CI.
+      # online-audits disabled: the repo-sync-managed poseidon.yaml references
+      # a8cteam51/poseidon-actions/*@trunk, which the scoped CI token can't resolve
+      # cross-repo (zizmor's online ref-confusion audit errors out). Offline audits run.
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
         continue-on-error: ${{ github.event.repository.visibility != 'public' }}
         with:
           advanced-security: ${{ github.event.repository.visibility == 'public' }}
+          online-audits: false


### PR DESCRIPTION
The poseidon/triton workflows reference a8cteam51/poseidon-actions/*@trunk. In CI the scoped GITHUB_TOKEN can't read the private poseidon-actions repo, so zizmor's online ref-confusion audit errors out (couldn't list branches) and exits non-zero. Set online-audits: false so zizmor runs only its offline audits (which all pass); Dependabot + SHA-pinning cover dependency-vuln checking.

Assisted-by: Claude Code:claude-opus-4-8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize security audit processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->