### PR TITLE
zizmor: scope to .github/workflows (skip vendored third-party CI)

### DIFF
--- a/.github/workflows/workflow-checks.yml
+++ b/.github/workflows/workflow-checks.yml
@@ -57,5 +57,8 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
         continue-on-error: ${{ github.event.repository.visibility != 'public' }}
         with:
+          # Scope to this repo's own workflows -- don't audit third-party CI
+          # files a scaffolded project may commit under vendor/ or node_modules/.
+          inputs: .github/workflows
           advanced-security: ${{ github.event.repository.visibility == 'public' }}
           online-audits: false


### PR DESCRIPTION
zizmor's default input is the repo root, so it was auditing CI files that ship inside committed dependencies (plugins/*/vendor/amphp/.github/workflows/*, etc.) -- findings that aren't ours. Scope inputs to .github/workflows so it audits only this repo's own workflows. On the scaffolds this also keeps scaffolded projects clean if they commit vendor/.

Assisted-by: Claude Code:claude-opus-4-8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to focus on the repository's own workflows, improving audit efficiency by excluding third-party dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->